### PR TITLE
Feat : 공통 에러처리 구현

### DIFF
--- a/src/main/java/com/mola/domain/chat/ChatInterceptor.java
+++ b/src/main/java/com/mola/domain/chat/ChatInterceptor.java
@@ -1,13 +1,14 @@
 package com.mola.domain.chat;
 
 import com.mola.domain.tripFriends.TripFriendsService;
+import com.mola.global.exception.CustomException;
+import com.mola.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -50,20 +51,20 @@ public class ChatInterceptor implements ChannelInterceptor {
 
     private void verifyTripFriends(Long memberId, Long tripPlanId) {
         if (!tripFriendsService.existsByMemberAndTripPlan(memberId, tripPlanId)) {
-            throw new AccessDeniedException("유효하지 않은 채팅 요청입니다.");
+            throw new CustomException(ErrorCode.InvalidTripFriends);
         }
     }
 
     private Long validateAndGetMemberId(Authentication authentication) {
         if (!(authentication.getPrincipal() instanceof Long)) {
-            throw new IllegalArgumentException("잘못된 회원 식별자 형식입니다.");
+            throw new CustomException(ErrorCode.InvalidMemberIdentifierFormat);
         }
         return (Long) authentication.getPrincipal();
     }
 
     private static void verifyDestination(String destination) {
         if (destination == null || (!destination.startsWith("/sub/") && !destination.startsWith("/pub/"))) {
-            throw new IllegalArgumentException("잘못된 목적지 형식입니다.");
+            throw new CustomException(ErrorCode.InvalidDestination);
         }
     }
 
@@ -71,18 +72,18 @@ public class ChatInterceptor implements ChannelInterceptor {
         try {
             String[] parts = destination.split("/");
             if (parts.length < 2) {
-                throw new IllegalArgumentException("식별자 값이 존재하지 않습니다.");
+                throw new CustomException(ErrorCode.MissingTripPlanIdentifier);
             }
-            return Long.parseLong(parts[1]);
+            return Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("잘못된 식별자 형식입니다.", e);
+            throw new CustomException(ErrorCode.InvalidTripPlanIdentifierFormat);
         }
     }
 
     private static Authentication getAndVerifyAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
+            throw new CustomException(ErrorCode.UnAuthorized);
         }
         return authentication;
     }

--- a/src/main/java/com/mola/global/exception/CustomException.java
+++ b/src/main/java/com/mola/global/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.mola.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/mola/global/exception/ErrorCode.java
+++ b/src/main/java/com/mola/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.mola.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    UnAuthorized(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    AccessDenied(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+    InvalidTripFriends(HttpStatus.BAD_REQUEST, "해당 TripPlan에 속한 사용자가 아닙니다."),
+    InvalidDestination(HttpStatus.BAD_REQUEST, "잘못된 목적지 형식입니다."),
+    InvalidMemberIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 회원 식별자 형식입니다."),
+    InvalidTripPlanIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 TripPlan 식별자 형식입니다."),
+    MissingTripPlanIdentifier(HttpStatus.BAD_REQUEST, "TripPlan 식별자가 누락되었습니다.");
+
+
+
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}

--- a/src/main/java/com/mola/global/exception/ErrorResponseDto.java
+++ b/src/main/java/com/mola/global/exception/ErrorResponseDto.java
@@ -1,0 +1,12 @@
+package com.mola.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public class ErrorResponseDto {
+    private HttpStatus status;
+    private String errorMessage;
+}

--- a/src/main/java/com/mola/global/exception/ExceptionController.java
+++ b/src/main/java/com/mola/global/exception/ExceptionController.java
@@ -1,0 +1,19 @@
+package com.mola.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDto> customExceptionHandler(CustomException e){
+        ErrorResponseDto response = new ErrorResponseDto(e.getErrorCode().getHttpStatus(),
+                e.getErrorCode().getErrorMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
+    }
+
+
+}

--- a/src/test/java/com/mola/domain/chat/ChatInterceptorTest.java
+++ b/src/test/java/com/mola/domain/chat/ChatInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.mola.domain.chat;
 
 import com.mola.domain.tripFriends.TripFriendsService;
+import com.mola.global.exception.CustomException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -76,7 +76,7 @@ class ChatInterceptorTest {
         when(securityContext.getAuthentication()).thenReturn(auth);
 
         // expect
-        assertThrows(IllegalArgumentException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
     @DisplayName("사용자 정보가 없는 메시지 요청은 에러를 반환")
@@ -89,7 +89,7 @@ class ChatInterceptorTest {
         when(securityContext.getAuthentication()).thenReturn(null);
 
         // expect
-        assertThrows(AccessDeniedException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
     @DisplayName("목적지 경로가 잘못된 메시지는 에러를 반환")
@@ -102,7 +102,7 @@ class ChatInterceptorTest {
         when(securityContext.getAuthentication()).thenReturn(createAuthentication());
 
         // expect
-        assertThrows(IllegalArgumentException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
     @DisplayName("목적지 경로가 없는 메시지는 에러를 반환")
@@ -114,7 +114,7 @@ class ChatInterceptorTest {
         when(securityContext.getAuthentication()).thenReturn(createAuthentication());
 
         // expect
-        assertThrows(IllegalArgumentException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
 
@@ -128,7 +128,7 @@ class ChatInterceptorTest {
         when(securityContext.getAuthentication()).thenReturn(createAuthentication());
 
         // expect
-        assertThrows(IllegalArgumentException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
     @DisplayName("회원이 속한 여행플랜이 아닌 메시지는 에러를 반환")
@@ -142,7 +142,7 @@ class ChatInterceptorTest {
         when(tripFriendsService.existsByMemberAndTripPlan(anyLong(), anyLong())).thenReturn(false);
 
         // expect
-        assertThrows(AccessDeniedException.class, () -> chatInterceptor.preSend(message, messageChannel));
+        assertThrows(CustomException.class, () -> chatInterceptor.preSend(message, messageChannel));
     }
 
     private Authentication createAuthentication(){


### PR DESCRIPTION
## 🙆‍♂️ Issue
#23 

## 📝 Description
서비스의 공통적인 에러처리를 위한 
RestControllerAdvice 클래스를 구현했어요.
커스텀한 Error 를 ErrorCode 클래스에 추가할 수 있어요.
응답으로 보낼 ErrorResponseDto 클래스를 구현했어요.
에러처리 로직이 바뀌어서 기존의 코드를 조금씩 수정했어요.


## ✨ Feature
어떤 기능인지 나열해주세요.
1. 커스텀한 에러를 만들고 처리하는 기능


## 👌 Review
This closes #23 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
