### PR TITLE
Refactor : 에러코드 확장성 향상

### DIFF
--- a/src/main/java/com/mola/domain/trip/exception/TripErrorCode.java
+++ b/src/main/java/com/mola/domain/trip/exception/TripErrorCode.java
@@ -1,0 +1,16 @@
+package com.mola.domain.trip.exception;
+
+import com.mola.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum TripErrorCode implements ErrorCode {
+    TripNotFound(HttpStatus.NOT_FOUND, "해당 여행 계획을 찾을 수 없습니다."),
+    TripAccessDenied(HttpStatus.FORBIDDEN, "이 여행 계획에 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}

--- a/src/main/java/com/mola/domain/trip/exception/TripException.java
+++ b/src/main/java/com/mola/domain/trip/exception/TripException.java
@@ -1,0 +1,9 @@
+package com.mola.domain.trip.exception;
+
+import com.mola.global.exception.CustomException;
+
+public class TripException extends CustomException {
+    public TripException(TripErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/mola/global/exception/ErrorCode.java
+++ b/src/main/java/com/mola/global/exception/ErrorCode.java
@@ -1,24 +1,8 @@
 package com.mola.global.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@AllArgsConstructor
-@Getter
-public enum ErrorCode {
-
-    UnAuthorized(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
-    AccessDenied(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
-    InvalidTripFriends(HttpStatus.BAD_REQUEST, "해당 TripPlan에 속한 사용자가 아닙니다."),
-    InvalidDestination(HttpStatus.BAD_REQUEST, "잘못된 목적지 형식입니다."),
-    InvalidMemberIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 회원 식별자 형식입니다."),
-    InvalidTripPlanIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 TripPlan 식별자 형식입니다."),
-    MissingTripPlanIdentifier(HttpStatus.BAD_REQUEST, "TripPlan 식별자가 누락되었습니다.");
-
-
-
-
-    private final HttpStatus httpStatus;
-    private final String errorMessage;
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getErrorMessage();
 }

--- a/src/main/java/com/mola/global/exception/ExceptionController.java
+++ b/src/main/java/com/mola/global/exception/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.mola.global.exception;
 
+import com.mola.domain.trip.exception.TripException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,5 +16,10 @@ public class ExceptionController {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
     }
 
+    @ExceptionHandler(TripException.class)
+    public ResponseEntity<ErrorResponseDto> handleTripException(TripException e) {
+        ErrorResponseDto response = new ErrorResponseDto(e.getErrorCode().getHttpStatus(), e.getErrorCode().getErrorMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
+    }
 
 }

--- a/src/main/java/com/mola/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/mola/global/exception/GlobalErrorCode.java
@@ -1,0 +1,21 @@
+package com.mola.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum GlobalErrorCode implements ErrorCode {
+
+    UnAuthorized(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    AccessDenied(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+    InvalidTripFriends(HttpStatus.BAD_REQUEST, "해당 TripPlan에 속한 사용자가 아닙니다."),
+    InvalidDestination(HttpStatus.BAD_REQUEST, "잘못된 목적지 형식입니다."),
+    InvalidMemberIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 회원 식별자 형식입니다."),
+    InvalidTripPlanIdentifierFormat(HttpStatus.BAD_REQUEST, "잘못된 TripPlan 식별자 형식입니다."),
+    MissingTripPlanIdentifier(HttpStatus.BAD_REQUEST, "TripPlan 식별자가 누락되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue
#45 

## 📝 Description
ErrorCode 를 인터페이스를 변경하였고 이전 ErrorCode를 GlobalErrorCode를 변경하였습니다.
이제 ErrorCode를 상속함으로서 도메인별 ErrorCode를 생성할 수 있습니다.


## ✨ Feature
어떤 기능인지 나열해주세요.
1. ErrorCode를 인터페이스로 변경
2. GlobalErrorCode 클래스 생성
3. Trip관련 예외코드 생성


## 👌 Review
This closes #45 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
